### PR TITLE
Fix: Add timeout to RtsImport function host.json

### DIFF
--- a/src/Functions/Rsp.RtsImport/host.json
+++ b/src/Functions/Rsp.RtsImport/host.json
@@ -9,5 +9,5 @@
       "enableLiveMetricsFilters": true
     }
   },
-  "functionTimeout": "00:30:00" // 30 minutes
+  "functionTimeout": "00:30:00"
 }


### PR DESCRIPTION
## What was the purpose of this ticket?

To increase the function timeout, but removed the comments

## Jira Ref

N/A

## Type of Change

Put [X] inside the [] to make the box ticked

- [ ] New feature
- [ ] Refactoring
- [X] Bug-fix
- [ ] DevOps
- [ ] Testing

## Solution

What work was completed to cover off the story?

- Increased the timeout for the RtsImport function to 30 minutes.