### PR TITLE
Fix: Add Bearer Token Caching

### DIFF
--- a/src/Functions/Rsp.RtsImport/Application/Contracts/ITokenService.cs
+++ b/src/Functions/Rsp.RtsImport/Application/Contracts/ITokenService.cs
@@ -1,0 +1,14 @@
+﻿namespace Rsp.RtsImport.Application.Contracts;
+
+/// <summary>
+/// Defines a contract for a service that provides access tokens.
+/// </summary>
+public interface ITokenService
+{
+    /// <summary>
+    /// Asynchronously retrieves an access token.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the access token as a string.</returns>
+    Task<string> GetAccessTokenAsync(CancellationToken cancellationToken);
+}

--- a/src/Functions/Rsp.RtsImport/Application/Settings/AppSettings.cs
+++ b/src/Functions/Rsp.RtsImport/Application/Settings/AppSettings.cs
@@ -11,4 +11,14 @@ public class AppSettings
     public Uri RtsApiBaseUrl { get; set; } = null!;
     public Uri RtsAuthApiBaseUrl { get; set; } = null!;
     public AzureAppConfiguration AzureAppConfiguration { get; set; } = null!;
+
+    /// <summary>
+    /// Database command timeout in seconds
+    /// </summary>
+    public int DatabaseCommandTimeout { get; set; }
+
+    /// <summary>
+    /// Timeout for bulk copy operations in seconds
+    /// </summary>
+    public int BulkCopyTimeout { get; set; }
 }

--- a/src/Functions/Rsp.RtsImport/Properties/launchSettings.json
+++ b/src/Functions/Rsp.RtsImport/Properties/launchSettings.json
@@ -1,11 +1,11 @@
 {
-    "profiles": {
-        "Rsp.RtsImport": {
-            "commandName": "Project",
-            "commandLineArgs": "--port 7264",
-            "environmentVariables": {
-                "DOTNET_ENVIRONMENT": "Development"
-            }
-        }
+  "profiles": {
+    "Rsp.RtsImport": {
+      "commandName": "Project",
+      "commandLineArgs": "--port 7264",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
     }
+  }
 }

--- a/src/Functions/Rsp.RtsImport/Services/TokenService.cs
+++ b/src/Functions/Rsp.RtsImport/Services/TokenService.cs
@@ -1,0 +1,73 @@
+﻿using Azure.Core;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Rsp.Logging.Extensions;
+using Rsp.RtsImport.Application.Contracts;
+using Rsp.RtsImport.Application.ServiceClients;
+using AppSettings = Rsp.RtsImport.Application.Settings.AppSettings;
+
+namespace Rsp.RtsImport.Services;
+
+/// <summary>
+/// Service responsible for managing and retrieving access tokens for authentication.
+/// </summary>
+public class TokenService
+(
+    IMemoryCache memoryCache, // Cache for storing the access token temporarily
+    IRtsAuthorisationServiceClient authClient, // Client for interacting with the authorization service
+    AppSettings appSettings, // Application settings containing client credentials
+    ILogger<TokenService> logger // Logger for logging errors and information
+) : ITokenService
+{
+    private const string TokenCacheKey = "NIHR_BearerToken"; // Key used to store the token in the cache
+
+    /// <summary>
+    /// Retrieves an access token, either from the cache or by requesting a new one from the authorization service.
+    /// </summary>
+    /// <returns>A valid access token as a string.</returns>
+    public async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken)
+    {
+        // Check if the token is already cached
+        if (memoryCache.TryGetValue(TokenCacheKey, out string? token))
+        {
+            return token!; // Return the cached token
+        }
+
+        // Build the request body using client credentials from app settings
+        var credentials = new Dictionary<string, string>
+        {
+            { "grant_type", "client_credentials" },
+            { "client_id", Uri.EscapeDataString(appSettings.RtsApiClientId ?? string.Empty) },
+            { "client_secret", Uri.EscapeDataString(appSettings.RtsApiClientSecret ?? string.Empty) },
+            { "scope", "openid profile email" }
+        };
+
+        // Encode the credentials into a form-urlencoded content
+        var encodedContent = new FormUrlEncodedContent(credentials);
+
+        // Read the encoded content as a string
+        var requestBody = await encodedContent.ReadAsStringAsync();
+
+        // Request a new token from the authorization service
+        var tokenResponse = await authClient.GetBearerTokenAsync(requestBody, cancellationToken);
+
+        // Check if the token retrieval was successful
+        if (!tokenResponse.IsSuccessStatusCode || string.IsNullOrWhiteSpace(tokenResponse.Content?.AccessToken))
+        {
+            // Log the error details
+            var parameters = $"Status code: {tokenResponse.StatusCode}, Error: {tokenResponse.Error?.Message}";
+            logger.LogAsError(parameters, "ERR_TOKEN_RETRIEVAL_FAILED", "Failed to retrieve access token", tokenResponse.Error);
+
+            return string.Empty; // Return an empty string if token retrieval failed
+        }
+
+        // Calculate the cache duration (token lifetime minus a buffer of 5 minutes)
+        var expiresIn = tokenResponse.Content.ExpiresIn;
+        var cacheDuration = TimeSpan.FromSeconds(expiresIn - 300);
+
+        // Cache the token for the calculated duration
+        memoryCache.Set(TokenCacheKey, tokenResponse.Content.AccessToken, cacheDuration);
+
+        return tokenResponse.Content.AccessToken; // Return the retrieved token
+    }
+}

--- a/src/Functions/Rsp.RtsImport/Startup/Configuration/ServicesConfiguration.cs
+++ b/src/Functions/Rsp.RtsImport/Startup/Configuration/ServicesConfiguration.cs
@@ -16,6 +16,7 @@ public static class ServicesConfiguration
         services.AddTransient<IMetadataService, MetadataService>();
         services.AddTransient<IOrganisationService, OrganisationsService>();
         services.AddTransient<IOrganisationImportService, OrganisationImportService>();
+        services.AddTransient<ITokenService, TokenService>();
 
         services.AddTransient<RtsAuthHeadersHandler>();
 

--- a/src/Functions/Rsp.RtsImport/Startup/Program.cs
+++ b/src/Functions/Rsp.RtsImport/Startup/Program.cs
@@ -31,6 +31,7 @@ public static class Program
             .AddEnvironmentVariables();
 
         // register dependencies
+        builder.Services.AddMemoryCache();
         builder.Services.AddServices();
         builder.Services.AddDbContext<RtsDbContext>(options =>
         {

--- a/src/Functions/Rsp.RtsImport/local.settings.json
+++ b/src/Functions/Rsp.RtsImport/local.settings.json
@@ -1,22 +1,24 @@
 {
-    "IsEncrypted": false,
-    "Values": {
-        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-        "RtsTimerSchedule": "0 0 7 * * *"
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "RtsTimerSchedule": "0 0 7 * * *"
+  },
+  "ConnectionStrings": {
+    "RtsDB": "Server=(localdb)\\mssqllocaldb;Database=RtsService;Trusted_Connection=True;MultipleActiveResultSets=true;Connection Timeout=120"
+  },
+  "AppSettings": {
+    "AzureAppConfiguration": {
+      "Endpoint": "",
+      "IdentityClientID": ""
     },
-    "ConnectionStrings": {
-        "RtsDB": "Server=(localdb)\\mssqllocaldb;Database=RtsService;Trusted_Connection=True;MultipleActiveResultSets=true;Connection Timeout=120"
-    },
-    "AppSettings": {
-        "AzureAppConfiguration": {
-            "Endpoint": "",
-            "IdentityClientID": ""
-        },
-        "AzureVaultUri": "",
-        "RtsApiBaseUrl": "",
-        "RtsApiClientId": "",
-        "RtsApiClientSecret": "",
-        "RtsAuthApiBaseUrl": ""
-    }
+    "AzureVaultUri": "",
+    "RtsApiBaseUrl": "",
+    "RtsApiClientId": "",
+    "RtsApiClientSecret": "",
+    "RtsAuthApiBaseUrl": "",
+    "DatabaseCommandTimeout": 500,
+    "BulkCopyTimeout": 500
+  }
 }

--- a/src/WebApi/Rsp.RtsService.WebApi/Rsp.RtsService.WebApi.csproj
+++ b/src/WebApi/Rsp.RtsService.WebApi/Rsp.RtsService.WebApi.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\..\..\rsp-service-defaults\src\Rsp.ServiceDefaults\Rsp.ServiceDefaults.csproj" />
 		<ProjectReference Include="..\..\Application\Rsp.RtsService.Application\Rsp.RtsService.Application.csproj" />
 	</ItemGroup>
 

--- a/tests/UnitTests/Rts.RtsImport.UnitTests/Services/TokenServiceTests.cs
+++ b/tests/UnitTests/Rts.RtsImport.UnitTests/Services/TokenServiceTests.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using Refit;
+using Rsp.RtsImport.Application.DTO.Responses;
+using Rsp.RtsImport.Application.ServiceClients;
+using Rsp.RtsImport.Services;
+using Shouldly;
+
+namespace Rts.RtsImport.UnitTests.Services;
+
+public class TokenServiceTests : TestServiceBase
+{
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
+    [Fact]
+    public async Task GetAccessTokenAsync_ShouldReturnToken_FromCache()
+    {
+        // Arrange
+        const string expectedToken = "cached-token";
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+
+        memoryCache.Set("NIHR_BearerToken", expectedToken);
+
+        Mocker.Use<IMemoryCache>(memoryCache);
+
+        var tokenService = Mocker.CreateInstance<TokenService>();
+
+        // Act
+        var token = await tokenService.GetAccessTokenAsync(_cancellationToken);
+
+        // Assert
+        token.ShouldBe(expectedToken);
+    }
+
+    [Fact]
+    public async Task GetAccessTokenAsync_ShouldFetchToken_AndCacheIt_WhenNotInCache()
+    {
+        // Arrange
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+
+        const string expectedToken = "new-token";
+        const int expiresIn = 3600;
+
+        var tokenResponse = new RtsAuthResponse
+        {
+            AccessToken = expectedToken,
+            ExpiresIn = expiresIn
+        };
+
+        Mocker
+            .GetMock<IRtsAuthorisationServiceClient>()
+            .Setup(c => c.GetBearerTokenAsync(It.IsAny<string>(), _cancellationToken))
+            .ReturnsAsync(new ApiResponse<RtsAuthResponse?>
+            (
+                new HttpResponseMessage(HttpStatusCode.OK),
+                tokenResponse,
+                new()
+            ));
+
+        Mocker.Use<IMemoryCache>(memoryCache);
+
+        var tokenService = Mocker.CreateInstance<TokenService>();
+
+        // Act
+        var token = await tokenService.GetAccessTokenAsync(_cancellationToken);
+
+        // Assert
+        token.ShouldBe(expectedToken);
+
+        memoryCache.TryGetValue("NIHR_BearerToken", out string? cachedToken).ShouldBeTrue();
+        cachedToken.ShouldBe(expectedToken);
+    }
+
+    [Fact]
+    public async Task GetAccessTokenAsync_ShouldReturnEmptyString_WhenTokenRetrievalFails()
+    {
+        // Arrange
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+
+        Mocker
+            .GetMock<IRtsAuthorisationServiceClient>()
+            .Setup(c => c.GetBearerTokenAsync(It.IsAny<string>(), _cancellationToken))
+            .ReturnsAsync(new ApiResponse<RtsAuthResponse?>
+            (
+                new HttpResponseMessage(HttpStatusCode.InternalServerError),
+                null,
+                new()
+            ));
+
+        Mocker.Use<IMemoryCache>(memoryCache);
+
+        var tokenService = Mocker.CreateInstance<TokenService>();
+
+        // Act
+        var token = await tokenService.GetAccessTokenAsync(_cancellationToken);
+
+        // Assert
+        token.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(" ")]
+    [InlineData("")]
+    public async Task GetAccessTokenAsync_ShouldReturnEmptyString_WhenAccessTokenIsNullOrWhitespace(string? accessToken)
+    {
+        // Arrange
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+
+        Mocker
+            .GetMock<IRtsAuthorisationServiceClient>()
+            .Setup(c => c.GetBearerTokenAsync(It.IsAny<string>(), _cancellationToken))
+            .ReturnsAsync(new ApiResponse<RtsAuthResponse?>
+            (
+                new HttpResponseMessage(HttpStatusCode.InternalServerError),
+                new RtsAuthResponse
+                {
+                    AccessToken = accessToken!,
+                    ExpiresIn = 3600
+                },
+                new()
+            ));
+
+        Mocker.Use<IMemoryCache>(memoryCache);
+
+        var tokenService = Mocker.CreateInstance<TokenService>();
+
+        // Act
+        var token = await tokenService.GetAccessTokenAsync(_cancellationToken);
+
+        // Assert
+        token.ShouldBeEmpty();
+    }
+}

--- a/tests/UnitTests/Rts.RtsImport.UnitTests/TestServiceBase{T}.cs
+++ b/tests/UnitTests/Rts.RtsImport.UnitTests/TestServiceBase{T}.cs
@@ -1,0 +1,15 @@
+﻿namespace Rts.RtsImport.UnitTests;
+
+public class TestServiceBase<T> : TestServiceBase where T : class
+{
+    public T Sut { get; set; }
+
+    public TestServiceBase()
+    {
+        // creating instance this way will inject
+        // a default mocked instances of all the dependencies
+        // which can be retreived by calling Mocker.GetMock<>
+        // e.g. Mocker.GetMock<ICategoriesService>() will return the injected instance for ICategoriesService
+        Sut = Mocker.CreateInstance<T>();
+    }
+}


### PR DESCRIPTION
## What was the purpose of this ticket?

To cache the bearer token so we don't need to fetch until it's about to expire.

## Jira Ref

N/A

## Type of Change

Put [X] inside the [] to make the box ticked

- [ ] New feature
- [X] Refactoring
- [ ] Bug-fix
- [ ] DevOps
- [X] Testing

## Solution

What work was completed to cover off the story?

- Added a new TokenService to handle BearerToken caching.
- Updated RtsAuthHeadersHandler to use the new TokenService.
- Updated ServicesConfiguration to register the new TokenService.
- Added Memory Cache.