### PR TITLE
Rsp 4063 organisation search and view list

### DIFF
--- a/src/Application/Rsp.RtsService.Application/Contracts/Repositories/IOrganisationRespository.cs
+++ b/src/Application/Rsp.RtsService.Application/Contracts/Repositories/IOrganisationRespository.cs
@@ -5,7 +5,7 @@ namespace Rsp.RtsService.Application.Contracts.Repositories;
 
 public interface IOrganisationRepository
 {
-    Task<(IEnumerable<Organisation>, int)> GetBySpecification(ISpecification<Organisation> specification, int pageSize);
+    Task<(IEnumerable<Organisation>, int)> GetBySpecification(ISpecification<Organisation> specification, int pageIndex, int? pageSize);
 
     Task<Organisation?> GetById(ISpecification<Organisation> specification);
 }

--- a/src/Application/Rsp.RtsService.Application/Contracts/Repositories/IOrganisationRespository.cs
+++ b/src/Application/Rsp.RtsService.Application/Contracts/Repositories/IOrganisationRespository.cs
@@ -5,7 +5,7 @@ namespace Rsp.RtsService.Application.Contracts.Repositories;
 
 public interface IOrganisationRepository
 {
-    Task<(IEnumerable<Organisation>, int)> SearchByName(ISpecification<Organisation> specification, int pageSize);
+    Task<(IEnumerable<Organisation>, int)> GetBySpecification(ISpecification<Organisation> specification, int pageSize);
 
     Task<Organisation?> GetById(ISpecification<Organisation> specification);
 }

--- a/src/Application/Rsp.RtsService.Application/Contracts/Services/IOrganisationService.cs
+++ b/src/Application/Rsp.RtsService.Application/Contracts/Services/IOrganisationService.cs
@@ -18,19 +18,21 @@ public interface IOrganisationService
     /// <summary>
     /// Get all organisations
     /// </summary>
-    /// <param name="pageSize">The maximum number of results to return.</param>
+    /// <param name="pageIndex">Index (1-based) of page for paginated results.</param>
+    /// <param name="pageSize">Optional maximum number of results to return.</param>
     /// <param name="role">Optional role to filter organisations by.</param>
     /// <param name="sortOrder" >Sort order for the results, either ascending or descending.</param>
     /// <returns></returns>
-    Task<OrganisationSearchResponse> GetAll(int pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending);
+    Task<OrganisationSearchResponse> GetAll(int pageIndex, int? pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending);
 
     /// <summary>
     /// Searches for organisations by name, with optional role filtering and paging.
     /// </summary>
     /// <param name="name">The name or partial name of the organisation to search for.</param>
-    /// <param name="pageSize">The maximum number of results to return.</param>
+    /// <param name="pageIndex">Index (1-based) of page for paginated results.</param>
+    /// <param name="pageSize">Optional maximum number of results to return.</param>
     /// <param name="role">Optional role to filter organisations by.</param>
     /// <param name="sortOrder" >Sort order for the results, either ascending or descending.</param>
     /// <returns>A collection of organisation search results.</returns>
-    Task<OrganisationSearchResponse> SearchByName(string name, int pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending);
+    Task<OrganisationSearchResponse> SearchByName(string name, int pageIndex, int? pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending);
 }

--- a/src/Application/Rsp.RtsService.Application/Contracts/Services/IOrganisationService.cs
+++ b/src/Application/Rsp.RtsService.Application/Contracts/Services/IOrganisationService.cs
@@ -16,11 +16,21 @@ public interface IOrganisationService
     Task<GetOrganisationByIdDto> GetById(string id);
 
     /// <summary>
+    /// Get all organisations
+    /// </summary>
+    /// <param name="pageSize">The maximum number of results to return.</param>
+    /// <param name="role">Optional role to filter organisations by.</param>
+    /// <param name="sortOrder" >Sort order for the results, either ascending or descending.</param>
+    /// <returns></returns>
+    Task<OrganisationSearchResponse> GetAll(int pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending);
+
+    /// <summary>
     /// Searches for organisations by name, with optional role filtering and paging.
     /// </summary>
     /// <param name="name">The name or partial name of the organisation to search for.</param>
     /// <param name="pageSize">The maximum number of results to return.</param>
     /// <param name="role">Optional role to filter organisations by.</param>
+    /// <param name="sortOrder" >Sort order for the results, either ascending or descending.</param>
     /// <returns>A collection of organisation search results.</returns>
     Task<OrganisationSearchResponse> SearchByName(string name, int pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending);
 }

--- a/src/Application/Rsp.RtsService.Application/DTOS/Responses/OrganisationSearchResponse.cs
+++ b/src/Application/Rsp.RtsService.Application/DTOS/Responses/OrganisationSearchResponse.cs
@@ -8,7 +8,7 @@ public record OrganisationSearchResponse
     /// <summary>
     /// Collection of organisations that match the search criteria.
     /// </summary>
-    public IEnumerable<SearchOrganisationByNameDto> Organisations { get; set; } = null!;
+    public IEnumerable<SearchOrganisationDto> Organisations { get; set; } = null!;
 
     /// <summary>
     /// Total number of organisations that match the search criteria.

--- a/src/Application/Rsp.RtsService.Application/DTOS/Responses/SearchOrganisationByNameDto.cs
+++ b/src/Application/Rsp.RtsService.Application/DTOS/Responses/SearchOrganisationByNameDto.cs
@@ -1,7 +1,0 @@
-﻿namespace Rsp.RtsService.Application.DTOS.Responses;
-
-public record SearchOrganisationByNameDto
-{
-    public string Id { get; set; } = null!;
-    public string Name { get; set; } = null!;
-}

--- a/src/Application/Rsp.RtsService.Application/DTOS/Responses/SearchOrganisationDto.cs
+++ b/src/Application/Rsp.RtsService.Application/DTOS/Responses/SearchOrganisationDto.cs
@@ -1,0 +1,10 @@
+﻿namespace Rsp.RtsService.Application.DTOS.Responses;
+
+public record SearchOrganisationDto
+{
+    public string Id { get; set; } = null!;
+    public string Name { get; set; } = null!;
+    public string? Address { get; set; }
+    public string? CountryName { get; set; }
+    public string Type { get; set; } = null!;
+}

--- a/src/Application/Rsp.RtsService.Application/Specifications/OrganisationSpecification.cs
+++ b/src/Application/Rsp.RtsService.Application/Specifications/OrganisationSpecification.cs
@@ -37,4 +37,24 @@ public class OrganisationSpecification : Specification<Organisation>
             _ => Query
         };
     }
+
+    public OrganisationSpecification(string roleId, SortOrder sortOrder)
+    {
+        Query.AsNoTracking();
+
+        if (!string.IsNullOrEmpty(roleId))
+        {
+            Query.Where(x => x.Roles.Any(x => x.Id == roleId));
+        }
+
+        Query
+            .Where(x => x.Status == true);
+
+        _ = sortOrder switch
+        {
+            SortOrder.Ascending => Query.OrderBy(x => x.Name),
+            SortOrder.Descending => Query.OrderByDescending(x => x.Name),
+            _ => Query
+        };
+    }
 }

--- a/src/Infrastructure/Rsp.RtsService.Infrastructure/Repositories/OrganisationRepository.cs
+++ b/src/Infrastructure/Rsp.RtsService.Infrastructure/Repositories/OrganisationRepository.cs
@@ -19,11 +19,11 @@ public class OrganisationRepository(RtsDbContext context) : IOrganisationReposit
     }
 
     /// <summary>
-    /// Searches for organisations by name using the provided specification and page size.
+    /// Searches for organisations using the provided specification and page size.
     /// </summary>
     /// <param name="pageSize">The maximum number of records to return.</param>
     /// <param name="specification">The specification that defines the search criteria.</param>
-    public async Task<(IEnumerable<Organisation>, int)> SearchByName(ISpecification<Organisation> specification, int pageSize)
+    public async Task<(IEnumerable<Organisation>, int)> GetBySpecification(ISpecification<Organisation> specification, int pageSize)
     {
         /// count the total number of records that match the specification
         var count = await context

--- a/src/Infrastructure/Rsp.RtsService.Infrastructure/Repositories/OrganisationRepository.cs
+++ b/src/Infrastructure/Rsp.RtsService.Infrastructure/Repositories/OrganisationRepository.cs
@@ -21,9 +21,10 @@ public class OrganisationRepository(RtsDbContext context) : IOrganisationReposit
     /// <summary>
     /// Searches for organisations using the provided specification and page size.
     /// </summary>
-    /// <param name="pageSize">The maximum number of records to return.</param>
+    /// <param name="pageIndex">Index (1-based) of page for paginated results.</param>
+    /// <param name="pageSize">Optional maximum number of results to return.</param>
     /// <param name="specification">The specification that defines the search criteria.</param>
-    public async Task<(IEnumerable<Organisation>, int)> GetBySpecification(ISpecification<Organisation> specification, int pageSize)
+    public async Task<(IEnumerable<Organisation>, int)> GetBySpecification(ISpecification<Organisation> specification, int pageIndex, int? pageSize)
     {
         /// count the total number of records that match the specification
         var count = await context
@@ -31,14 +32,23 @@ public class OrganisationRepository(RtsDbContext context) : IOrganisationReposit
             .WithSpecification(specification)
             .CountAsync();
 
-        // only take the specified number of records
-        var organisations = await context
+        // Prepare the query
+        var query = context
             .Organisation
-            .WithSpecification(specification)
-            .Take(pageSize)
-            .ToListAsync();
+            .WithSpecification(specification);
 
-        // return the organisations and the count
+        // Apply pagination if pageSize is specified
+        if (pageSize.HasValue)
+        {
+            query = query
+                .Skip((pageIndex - 1) * pageSize.Value)
+                .Take(pageSize.Value);
+        }
+
+        // Execute the query
+        var organisations = await query.ToListAsync();
+
+        // Return the organisations and the total count
         return (organisations, count);
     }
 }

--- a/src/Services/Rsp.RtsService.Services/OrganisationService.cs
+++ b/src/Services/Rsp.RtsService.Services/OrganisationService.cs
@@ -18,14 +18,15 @@ public class OrganisationService(IOrganisationRepository repository) : IOrganisa
     /// <summary>
     /// Gets all organisations, with optional role filtering and paging.
     /// </summary>
-    /// <param name="pageSize"> The maximum number of results to return.</param>
+    /// <param name="pageIndex">Index (1-based) of page for paginated results.</param>
+    /// <param name="pageSize">Optional maximum number of results to return.</param>
     /// <param name="role">Optional role to filter organisations by.</param>
     /// <param name="sortOrder" >Sort order for the results, either ascending or descending.</param>
     /// <returns></returns>
     /// <exception cref="NotImplementedException"></exception>
-    public async Task<OrganisationSearchResponse> GetAll(int pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending)
+    public async Task<OrganisationSearchResponse> GetAll(int pageIndex, int? pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending)
     {
-        var (organisations, count) = await repository.GetBySpecification(new OrganisationSpecification(role!, sortOrder), pageSize);
+        var (organisations, count) = await repository.GetBySpecification(new OrganisationSpecification(role!, sortOrder), pageIndex, pageSize);
 
         return new OrganisationSearchResponse
         {
@@ -38,12 +39,13 @@ public class OrganisationService(IOrganisationRepository repository) : IOrganisa
     /// Searches for organisations by name, with optional role filtering and paging.
     /// </summary>
     /// <param name="name">The name or partial name of the organisation to search for.</param>
-    /// <param name="pageSize"> The maximum number of results to return.</param>
+    /// <param name="pageIndex">Index (1-based) of page for paginated results.</param>
+    /// <param name="pageSize">Optional maximum number of results to return.</param>
     /// <param name="role">Optional role to filter organisations by.</param>
     /// <param name="sortOrder" >Sort order for the results, either ascending or descending.</param>
-    public async Task<OrganisationSearchResponse> SearchByName(string name, int pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending)
+    public async Task<OrganisationSearchResponse> SearchByName(string name, int pageIndex, int? pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending)
     {
-        var (organisations, count) = await repository.GetBySpecification(new OrganisationSpecification(name, role!, sortOrder), pageSize);
+        var (organisations, count) = await repository.GetBySpecification(new OrganisationSpecification(name, role!, sortOrder), pageIndex, pageSize);
 
         return new OrganisationSearchResponse
         {

--- a/src/Services/Rsp.RtsService.Services/OrganisationService.cs
+++ b/src/Services/Rsp.RtsService.Services/OrganisationService.cs
@@ -22,8 +22,6 @@ public class OrganisationService(IOrganisationRepository repository) : IOrganisa
     /// <param name="pageSize">Optional maximum number of results to return.</param>
     /// <param name="role">Optional role to filter organisations by.</param>
     /// <param name="sortOrder" >Sort order for the results, either ascending or descending.</param>
-    /// <returns></returns>
-    /// <exception cref="NotImplementedException"></exception>
     public async Task<OrganisationSearchResponse> GetAll(int pageIndex, int? pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending)
     {
         var (organisations, count) = await repository.GetBySpecification(new OrganisationSpecification(role!, sortOrder), pageIndex, pageSize);

--- a/src/Services/Rsp.RtsService.Services/OrganisationService.cs
+++ b/src/Services/Rsp.RtsService.Services/OrganisationService.cs
@@ -16,6 +16,25 @@ public class OrganisationService(IOrganisationRepository repository) : IOrganisa
     }
 
     /// <summary>
+    /// Gets all organisations, with optional role filtering and paging.
+    /// </summary>
+    /// <param name="pageSize"> The maximum number of results to return.</param>
+    /// <param name="role">Optional role to filter organisations by.</param>
+    /// <param name="sortOrder" >Sort order for the results, either ascending or descending.</param>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
+    public async Task<OrganisationSearchResponse> GetAll(int pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending)
+    {
+        var (organisations, count) = await repository.GetBySpecification(new OrganisationSpecification(role!, sortOrder), pageSize);
+
+        return new OrganisationSearchResponse
+        {
+            Organisations = organisations.Adapt<IEnumerable<SearchOrganisationDto>>(),
+            TotalCount = count,
+        };
+    }
+
+    /// <summary>
     /// Searches for organisations by name, with optional role filtering and paging.
     /// </summary>
     /// <param name="name">The name or partial name of the organisation to search for.</param>
@@ -24,11 +43,11 @@ public class OrganisationService(IOrganisationRepository repository) : IOrganisa
     /// <param name="sortOrder" >Sort order for the results, either ascending or descending.</param>
     public async Task<OrganisationSearchResponse> SearchByName(string name, int pageSize, string? role = null, SortOrder sortOrder = SortOrder.Ascending)
     {
-        var (organisations, count) = await repository.SearchByName(new OrganisationSpecification(name, role!, sortOrder), pageSize);
+        var (organisations, count) = await repository.GetBySpecification(new OrganisationSpecification(name, role!, sortOrder), pageSize);
 
         return new OrganisationSearchResponse
         {
-            Organisations = organisations.Adapt<IEnumerable<SearchOrganisationByNameDto>>(),
+            Organisations = organisations.Adapt<IEnumerable<SearchOrganisationDto>>(),
             TotalCount = count,
         };
     }

--- a/src/WebApi/Rsp.RtsService.WebApi/Controllers/OrganisationController.cs
+++ b/src/WebApi/Rsp.RtsService.WebApi/Controllers/OrganisationController.cs
@@ -33,6 +33,24 @@ public class OrganisationsController(IOrganisationService orgService) : Controll
     }
 
     /// <summary>
+    /// Get all organisations.
+    /// </summary>
+    [HttpGet("getAll")]
+    public async Task<ActionResult<OrganisationSearchResponse>> GetAll(int pageSize = 5, string? role = null, string sort = "asc")
+    {
+        var sortOrder = sort switch
+        {
+            "asc" => SortOrder.Ascending,
+            "desc" => SortOrder.Descending,
+            _ => SortOrder.Ascending
+        };
+
+        var organisations = await orgService.GetAll(pageSize, role, sortOrder);
+
+        return Ok(organisations);
+    }
+
+    /// <summary>
     /// Get a single organisation by ID.
     /// </summary>
     [HttpGet("getById")]

--- a/src/WebApi/Rsp.RtsService.WebApi/Controllers/OrganisationController.cs
+++ b/src/WebApi/Rsp.RtsService.WebApi/Controllers/OrganisationController.cs
@@ -10,14 +10,32 @@ namespace Rsp.RtsService.WebApi.Controllers;
 public class OrganisationsController(IOrganisationService orgService) : ControllerBase
 {
     /// <summary>
-    /// Query organisations by complete or partial name..
+    /// Query organisations by complete or partial name
     /// </summary>
+    /// <param name="name">The name or partial name of the organisation to search for.</param>
+    /// <param name="pageIndex">1-based index of the page to retrieve. Must be greater than 0. If null, will be set to 1 by default.</param>
+    /// <param name="pageSize">Optional number of items per page. If null, all matching organisations are returned. Must be greater than 0 if specified.</param>
+    /// <param name="role">Optional role to filter organisations by.</param>
+    /// <param name="sort">Sort order for the results, either ascending or descending.</param>
+    /// <returns></returns>
     [HttpGet("searchByName")]
-    public async Task<ActionResult<OrganisationSearchResponse>> SearchByName(string name, int pageSize = 5, string? role = null, string sort = "asc")
+    public async Task<ActionResult<OrganisationSearchResponse>> SearchByName(string name, int? pageIndex = 1, int? pageSize = null, string? role = null, string sort = "asc")
     {
         if (name.Length < 3)
         {
             return BadRequest("Name needs to include minimum 3 characters");
+        }
+        if (pageIndex.HasValue && pageIndex <= 0)
+        {
+            return BadRequest("pageIndex must be greater than 0 if specified.");
+        }
+        else if (!pageIndex.HasValue)
+        {
+            pageIndex = 1;
+        }
+        if (pageSize.HasValue && pageSize <= 0)
+        {
+            return BadRequest("pageSize must be greater than 0 if specified.");
         }
 
         var sortOrder = sort switch
@@ -27,17 +45,35 @@ public class OrganisationsController(IOrganisationService orgService) : Controll
             _ => SortOrder.Ascending
         };
 
-        var organisations = await orgService.SearchByName(name, pageSize, role, sortOrder);
+        var organisations = await orgService.SearchByName(name, pageIndex.Value, pageSize, role, sortOrder);
 
         return Ok(organisations);
     }
 
     /// <summary>
-    /// Get all organisations.
+    /// Retrives a paginated list of all organisations
     /// </summary>
+    /// <param name="pageIndex">1-based index of the page to retrieve. Must be greater than 0. If null, will be set to 1 by default.</param>
+    /// <param name="pageSize">Optional number of items per page. If null, all matching organisations are returned. Must be greater than 0 if specified.</param>
+    /// <param name="role">Optional role to filter organisations by.</param>
+    /// <param name="sort">Sort order for the results, either ascending or descending.</param>
+    /// <returns></returns>
     [HttpGet("getAll")]
-    public async Task<ActionResult<OrganisationSearchResponse>> GetAll(int pageSize = 5, string? role = null, string sort = "asc")
+    public async Task<ActionResult<OrganisationSearchResponse>> GetAll(int? pageIndex = 1, int? pageSize = null, string? role = null, string sort = "asc")
     {
+        if (pageIndex.HasValue && pageIndex <= 0)
+        {
+            return BadRequest("pageIndex must be greater than 0 if specified.");
+        }
+        else if (!pageIndex.HasValue)
+        {
+            pageIndex = 1;
+        }
+        if (pageSize.HasValue && pageSize <= 0)
+        {
+            return BadRequest("pageSize must be greater than 0 if specified.");
+        }
+
         var sortOrder = sort switch
         {
             "asc" => SortOrder.Ascending,
@@ -45,7 +81,7 @@ public class OrganisationsController(IOrganisationService orgService) : Controll
             _ => SortOrder.Ascending
         };
 
-        var organisations = await orgService.GetAll(pageSize, role, sortOrder);
+        var organisations = await orgService.GetAll(pageIndex.Value, pageSize, role, sortOrder);
 
         return Ok(organisations);
     }

--- a/src/WebApi/Rsp.RtsService.WebApi/Controllers/OrganisationController.cs
+++ b/src/WebApi/Rsp.RtsService.WebApi/Controllers/OrganisationController.cs
@@ -13,25 +13,21 @@ public class OrganisationsController(IOrganisationService orgService) : Controll
     /// Query organisations by complete or partial name
     /// </summary>
     /// <param name="name">The name or partial name of the organisation to search for.</param>
-    /// <param name="pageIndex">1-based index of the page to retrieve. Must be greater than 0. If null, will be set to 1 by default.</param>
+    /// <param name="pageIndex">1-based index of the page to retrieve. Must be greater than 0.</param>
     /// <param name="pageSize">Optional number of items per page. If null, all matching organisations are returned. Must be greater than 0 if specified.</param>
     /// <param name="role">Optional role to filter organisations by.</param>
     /// <param name="sort">Sort order for the results, either ascending or descending.</param>
     /// <returns></returns>
     [HttpGet("searchByName")]
-    public async Task<ActionResult<OrganisationSearchResponse>> SearchByName(string name, int? pageIndex = 1, int? pageSize = null, string? role = null, string sort = "asc")
+    public async Task<ActionResult<OrganisationSearchResponse>> SearchByName(string name, int pageIndex = 1, int? pageSize = null, string? role = null, string sort = "asc")
     {
         if (name.Length < 3)
         {
             return BadRequest("Name needs to include minimum 3 characters");
         }
-        if (pageIndex.HasValue && pageIndex <= 0)
+        if (pageIndex <= 0)
         {
             return BadRequest("pageIndex must be greater than 0 if specified.");
-        }
-        else if (!pageIndex.HasValue)
-        {
-            pageIndex = 1;
         }
         if (pageSize.HasValue && pageSize <= 0)
         {
@@ -45,7 +41,7 @@ public class OrganisationsController(IOrganisationService orgService) : Controll
             _ => SortOrder.Ascending
         };
 
-        var organisations = await orgService.SearchByName(name, pageIndex.Value, pageSize, role, sortOrder);
+        var organisations = await orgService.SearchByName(name, pageIndex, pageSize, role, sortOrder);
 
         return Ok(organisations);
     }
@@ -53,21 +49,17 @@ public class OrganisationsController(IOrganisationService orgService) : Controll
     /// <summary>
     /// Retrives a paginated list of all organisations
     /// </summary>
-    /// <param name="pageIndex">1-based index of the page to retrieve. Must be greater than 0. If null, will be set to 1 by default.</param>
+    /// <param name="pageIndex">1-based index of the page to retrieve. Must be greater than 0.</param>
     /// <param name="pageSize">Optional number of items per page. If null, all matching organisations are returned. Must be greater than 0 if specified.</param>
     /// <param name="role">Optional role to filter organisations by.</param>
     /// <param name="sort">Sort order for the results, either ascending or descending.</param>
     /// <returns></returns>
     [HttpGet("getAll")]
-    public async Task<ActionResult<OrganisationSearchResponse>> GetAll(int? pageIndex = 1, int? pageSize = null, string? role = null, string sort = "asc")
+    public async Task<ActionResult<OrganisationSearchResponse>> GetAll(int pageIndex = 1, int? pageSize = null, string? role = null, string sort = "asc")
     {
-        if (pageIndex.HasValue && pageIndex <= 0)
+        if (pageIndex <= 0)
         {
             return BadRequest("pageIndex must be greater than 0 if specified.");
-        }
-        else if (!pageIndex.HasValue)
-        {
-            pageIndex = 1;
         }
         if (pageSize.HasValue && pageSize <= 0)
         {
@@ -81,7 +73,7 @@ public class OrganisationsController(IOrganisationService orgService) : Controll
             _ => SortOrder.Ascending
         };
 
-        var organisations = await orgService.GetAll(pageIndex.Value, pageSize, role, sortOrder);
+        var organisations = await orgService.GetAll(pageIndex, pageSize, role, sortOrder);
 
         return Ok(organisations);
     }

--- a/tests/UnitTests/Rsp.RtsService.UnitTests/Controllers/OrganisationsControllerTests.cs
+++ b/tests/UnitTests/Rsp.RtsService.UnitTests/Controllers/OrganisationsControllerTests.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoFixture.Xunit2;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Rsp.RtsService.Application.Contracts.Services;
+using Rsp.RtsService.Application.DTOS.Responses;
+using Rsp.RtsService.Application.Enums;
+using Rsp.RtsService.WebApi.Controllers;
+using Shouldly;
+
+namespace Rsp.RtsService.UnitTests.Controllers;
+
+public class OrganisationsControllerTests : TestServiceBase
+{
+    private readonly OrganisationsController _controller;
+
+    public OrganisationsControllerTests()
+    {
+        _controller = Mocker.CreateInstance<OrganisationsController>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("a")]
+    [InlineData("ab")]
+    public async Task SearchByName_ShouldReturnBadRequest_WhenNameTooShort(string name)
+    {
+        var result = await _controller.SearchByName(name);
+
+        var badRequest = result.Result.ShouldBeOfType<BadRequestObjectResult>();
+        badRequest.Value.ShouldBe("Name needs to include minimum 3 characters");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task SearchByName_ShouldReturnBadRequest_WhenPageIndexInvalid(int pageIndex)
+    {
+        var result = await _controller.SearchByName("ValidName", pageIndex);
+
+        var badRequest = result.Result.ShouldBeOfType<BadRequestObjectResult>();
+        badRequest.Value.ShouldBe("pageIndex must be greater than 0 if specified.");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public async Task SearchByName_ShouldReturnBadRequest_WhenPageSizeInvalid(int pageSize)
+    {
+        var result = await _controller.SearchByName("ValidName", 1, pageSize);
+
+        var badRequest = result.Result.ShouldBeOfType<BadRequestObjectResult>();
+        badRequest.Value.ShouldBe("pageSize must be greater than 0 if specified.");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task GetAll_ShouldReturnBadRequest_WhenPageIndexInvalid(int pageIndex)
+    {
+        var result = await _controller.GetAll(pageIndex);
+
+        var badRequest = result.Result.ShouldBeOfType<BadRequestObjectResult>();
+        badRequest.Value.ShouldBe("pageIndex must be greater than 0 if specified.");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-10)]
+    public async Task GetAll_ShouldReturnBadRequest_WhenPageSizeInvalid(int pageSize)
+    {
+        var result = await _controller.GetAll(1, pageSize);
+
+        var badRequest = result.Result.ShouldBeOfType<BadRequestObjectResult>();
+        badRequest.Value.ShouldBe("pageSize must be greater than 0 if specified.");
+    }
+
+    [Theory]
+    [AutoData]
+    public async Task GetById_ShouldReturnOk_WhenFound(string id, GetOrganisationByIdDto dto)
+    {
+        var mock = Mocker.GetMock<IOrganisationService>();
+        mock.Setup(s => s.GetById(id)).ReturnsAsync(dto);
+
+        var result = await _controller.GetById(id);
+
+        var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+        ok.Value.ShouldBe(dto);
+    }
+
+    [Theory]
+    [AutoData]
+    public async Task GetAll_ShouldReturnOk_WhenValid(OrganisationSearchResponse response)
+    {
+        var mock = Mocker.GetMock<IOrganisationService>();
+        mock.Setup(s => s.GetAll(1, null, null, SortOrder.Ascending))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetAll();
+
+        var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+        ok.Value.ShouldBe(response);
+    }
+
+    [Theory]
+    [AutoData]
+    public async Task SearchByName_ShouldReturnOk_WhenValid(string name, OrganisationSearchResponse response)
+    {
+        var mock = Mocker.GetMock<IOrganisationService>();
+        mock.Setup(s => s.SearchByName(name, 1, null, null, SortOrder.Ascending))
+            .ReturnsAsync(response);
+
+        var result = await _controller.SearchByName(name);
+
+        var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+        ok.Value.ShouldBe(response);
+    }
+}

--- a/tests/UnitTests/Rsp.RtsService.UnitTests/Controllers/OrganisationsControllerTests.cs
+++ b/tests/UnitTests/Rsp.RtsService.UnitTests/Controllers/OrganisationsControllerTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AutoFixture.Xunit2;
+﻿using AutoFixture.Xunit2;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Rsp.RtsService.Application.Contracts.Services;

--- a/tests/UnitTests/Rsp.RtsService.UnitTests/Services/OrganisationServiceTests/GetAllTests.cs
+++ b/tests/UnitTests/Rsp.RtsService.UnitTests/Services/OrganisationServiceTests/GetAllTests.cs
@@ -1,0 +1,134 @@
+﻿using Ardalis.Specification;
+using AutoFixture;
+using AutoFixture.Xunit2;
+using Bogus;
+using Mapster;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Rsp.RtsService.Application.Contracts.Repositories;
+using Rsp.RtsService.Application.DTOS.Responses;
+using Rsp.RtsService.Application.Enums;
+using Rsp.RtsService.Application.Specifications;
+using Rsp.RtsService.Domain.Entities;
+using Rsp.RtsService.Infrastructure;
+using Rsp.RtsService.Infrastructure.Repositories;
+using Rsp.RtsService.Services;
+using Shouldly;
+
+namespace Rsp.RtsService.UnitTests.Services.OrganisationServiceTests;
+
+public class GetAllTests : TestServiceBase<OrganisationService>
+{
+    private readonly OrganisationRepository _rolesRepository;
+    private readonly RtsDbContext _context;
+
+    public GetAllTests()
+    {
+        var options = new DbContextOptionsBuilder<RtsDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString("N")).Options;
+
+        _context = new RtsDbContext(options);
+        _rolesRepository = new OrganisationRepository(_context);
+    }
+
+    [Theory]
+    [InlineAutoData(10)]
+    public async Task Returns_All_Organisations(int records, Generator<Organisation> generator)
+    {
+        // Arrange
+        int pageSize = 10;
+        Mocker.Use<IOrganisationRepository>(_rolesRepository);
+
+        var service = Mocker.CreateInstance<OrganisationService>();
+        var testOrganisations = await TestData.SeedData(_context, generator, records);
+
+        var expectedOrganisationIds = testOrganisations
+            .Where(x => x != null)
+            .OrderBy(x => x.Name)
+            .Select(x => x.Id)
+            .ToList();
+
+        // Act
+        var getResponse = await service.GetAll(pageSize, null);
+        var actualOrganisationIds = getResponse.Organisations.Select(x => x.Id).ToList();
+
+        // Assert
+        actualOrganisationIds.ShouldNotBeNull();
+        actualOrganisationIds.ShouldBeEquivalentTo(expectedOrganisationIds);
+    }
+
+    [Fact]
+    public async Task GetAll_Should_Pass_Correct_Specification_Parameters()
+    {
+        // Arrange
+        const string role = "Admin";
+        const SortOrder sortOrder = SortOrder.Descending;
+        const int pageSize = 10;
+
+        OrganisationSpecification? capturedSpec = null;
+
+        Mocker
+            .GetMock<IOrganisationRepository>()
+            .Setup(r => r.GetBySpecification(It.IsAny<OrganisationSpecification>(), It.IsAny<int>()))
+            .Callback((ISpecification<Organisation> spec, int _) => capturedSpec = spec as OrganisationSpecification)
+            .ReturnsAsync(([], 0));
+
+        // Act
+        await Sut.GetAll(pageSize, role, sortOrder);
+
+        // Assert
+        capturedSpec.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task GetAll_Should_Return_Mapped_Dtos()
+    {
+        // Arrange
+        int pageSize = 10;
+
+        var orgs = new List<Organisation>
+        {
+            new() { Id = "1", Name = "Org 1", Status = true, Address = "123 Main St", CountryName = "Poland", Type = "Local company" },
+            new() { Id = "2", Name = "Org 2", Status = true, Address = "125 Main St", CountryName = "England", Type = "Local company" }
+        };
+
+        var expectedDtos = orgs.Adapt<IEnumerable<SearchOrganisationDto>>();
+
+        Mocker
+            .GetMock<IOrganisationRepository>()
+            .Setup(r => r.GetBySpecification(It.IsAny<OrganisationSpecification>(), It.IsAny<int>()))
+            .ReturnsAsync((orgs, orgs.Count));
+
+        // Act
+        var result = await Sut.GetAll(pageSize);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldBeAssignableTo<OrganisationSearchResponse>();
+        result.Organisations.ShouldBe(expectedDtos, ignoreOrder: false);
+    }
+
+    [Theory, AutoData]
+    public async Task GetAll_Should_Return_TotalCount_Of_Records(Faker<Organisation> faker)
+    {
+        // Arrange
+        Mocker.Use<IOrganisationRepository>(_rolesRepository);
+
+        faker.RuleFor(o => o.Id, f => f.Random.Guid().ToString());
+        faker.RuleFor(o => o.Name, f => f.Company.CompanyName());
+        faker.RuleFor(o => o.Status, true);
+        faker.RuleFor(o => o.OId, f => f.Random.Guid().ToString());
+        faker.RuleFor(o => o.Type, f => f.Commerce.Department());
+        faker.RuleFor(o => o.TypeId, f => f.Random.Guid().ToString());
+        faker.RuleFor(o => o.TypeName, f => f.Commerce.ProductName());
+
+        var service = Mocker.CreateInstance<OrganisationService>();
+        var testOrganisations = await TestData.SeedData(_context, faker.Generate(10));
+
+        // Act
+        var response = await service.GetAll(5);
+
+        // Assert
+        response.TotalCount.ShouldBe(testOrganisations.Count());
+    }
+}

--- a/tests/UnitTests/Rsp.RtsService.UnitTests/Services/OrganisationServiceTests/SearchOrganisationByNameAndRole.cs
+++ b/tests/UnitTests/Rsp.RtsService.UnitTests/Services/OrganisationServiceTests/SearchOrganisationByNameAndRole.cs
@@ -60,6 +60,7 @@ public class SearchOrganisationByNameAndRole : TestServiceBase<OrganisationServi
     {
         // Arrange
         const string name = "Test";
+        const int pageIndex = 0;
         const int pageSize = 2;
 
         var orgs = new List<Organisation>
@@ -72,11 +73,11 @@ public class SearchOrganisationByNameAndRole : TestServiceBase<OrganisationServi
 
         Mocker
             .GetMock<IOrganisationRepository>()
-            .Setup(r => r.GetBySpecification(It.IsAny<OrganisationSpecification>(), It.IsAny<int>()))
+            .Setup(r => r.GetBySpecification(It.IsAny<OrganisationSpecification>(), It.IsAny<int>(), It.IsAny<int?>()))
             .ReturnsAsync((orgs, 2));
 
         // Act
-        var result = await Sut.SearchByName(name, pageSize);
+        var result = await Sut.SearchByName(name, pageIndex, pageSize);
 
         // Assert
         result.ShouldNotBeNull();
@@ -90,6 +91,7 @@ public class SearchOrganisationByNameAndRole : TestServiceBase<OrganisationServi
         // Arrange
         const string name = "Test";
         const int pageSize = 5;
+        const int pageIndex = 0;
         const string role = "Admin";
         const SortOrder sortOrder = SortOrder.Descending;
 
@@ -97,12 +99,12 @@ public class SearchOrganisationByNameAndRole : TestServiceBase<OrganisationServi
 
         Mocker
             .GetMock<IOrganisationRepository>()
-            .Setup(r => r.GetBySpecification(It.IsAny<OrganisationSpecification>(), It.IsAny<int>()))
-            .Callback((ISpecification<Organisation> spec, int _) => capturedSpec = spec as OrganisationSpecification)
+            .Setup(r => r.GetBySpecification(It.IsAny<OrganisationSpecification>(), It.IsAny<int>(), It.IsAny<int?>()))
+            .Callback((ISpecification<Organisation> spec, int _, int? _) => capturedSpec = spec as OrganisationSpecification)
             .ReturnsAsync(([], 0));
 
         // Act
-        await Sut.SearchByName(name, pageSize, role, sortOrder);
+        await Sut.SearchByName(name, pageIndex, pageSize, role, sortOrder);
 
         // Assert
         capturedSpec.ShouldNotBeNull();
@@ -128,7 +130,7 @@ public class SearchOrganisationByNameAndRole : TestServiceBase<OrganisationServi
         const string nameToTest = "nhs";
 
         // Act
-        var searchResponse = await service.SearchByName(nameToTest, 5, null);
+        var searchResponse = await service.SearchByName(nameToTest, 5, null, null);
 
         // Assert
         searchResponse.TotalCount.ShouldBe(testOrganisations.Count());

--- a/tests/UnitTests/Rsp.RtsService.UnitTests/Services/OrganisationServiceTests/SearchOrganisationByNameAndRole.cs
+++ b/tests/UnitTests/Rsp.RtsService.UnitTests/Services/OrganisationServiceTests/SearchOrganisationByNameAndRole.cs
@@ -64,15 +64,15 @@ public class SearchOrganisationByNameAndRole : TestServiceBase<OrganisationServi
 
         var orgs = new List<Organisation>
         {
-            new() { Id = "1", Name = "Test Org 1" },
-            new() { Id = "2", Name = "Test Org 2" }
+            new() { Id = "1", Name = "Org 1", Status = true, Address = "123 Main St", CountryName = "Poland", Type = "Local company" },
+            new() { Id = "2", Name = "Org 2", Status = true, Address = "125 Main St", CountryName = "England", Type = "Local company" }
         };
 
-        var expectedDtos = orgs.Adapt<IEnumerable<SearchOrganisationByNameDto>>();
+        var expectedDtos = orgs.Adapt<IEnumerable<SearchOrganisationDto>>();
 
         Mocker
             .GetMock<IOrganisationRepository>()
-            .Setup(r => r.SearchByName(It.IsAny<OrganisationSpecification>(), It.IsAny<int>()))
+            .Setup(r => r.GetBySpecification(It.IsAny<OrganisationSpecification>(), It.IsAny<int>()))
             .ReturnsAsync((orgs, 2));
 
         // Act
@@ -97,7 +97,7 @@ public class SearchOrganisationByNameAndRole : TestServiceBase<OrganisationServi
 
         Mocker
             .GetMock<IOrganisationRepository>()
-            .Setup(r => r.SearchByName(It.IsAny<OrganisationSpecification>(), It.IsAny<int>()))
+            .Setup(r => r.GetBySpecification(It.IsAny<OrganisationSpecification>(), It.IsAny<int>()))
             .Callback((ISpecification<Organisation> spec, int _) => capturedSpec = spec as OrganisationSpecification)
             .ReturnsAsync(([], 0));
 


### PR DESCRIPTION
## What was the purpose of this ticket?

Provide a brief description of the ticket :

User wants to search the RTS feed to find organisations, on the modification, Participating organisation area of change - organisation search page. This ticket adds possibility to get all organisations without filtering by name and adds possibility of pagination.

## Jira Ref

Replace the `###` with the Jira Ticket number below

[RSP-4063](https://nihr.atlassian.net/browse/RSP-4063)

## Type of Change

Put [X] inside the [] to make the box ticked

- [X] New feature
- [ ] Refactoring
- [ ] Bug-fix
- [ ] DevOps
- [ ] Testing

## Solution

What work was completed to cover off the story?

- List out changes made to the repo:
- Changed existing SearchByName command in controler and service - to accept both pageIndex and pageSize for pagination as optional parameters
- Added new GetAll command in controller and service with pagination for getting organisations without need to filter by name
- Changed SearchOrganisationDto to populate more properties (address, type, country)
- Added unit tests

## Checklist

- [X] Your code builds clean without any  warnings
- [X] You have added unit tests
- [X] All the added unit tests add value i.e. assert the right thing?
- [X] You are using the correct naming conventions
- [ ] You have fixed all the suggestions made by .editorconfig and/or Roslynator
- [X] There are no dead code and no "TODO" comments left
- [X] Please make sure that using statements are sorted with using System* statements at the top. You can use CTRL + K, CTRL + D command to format the file, that will respect the .editorconfig, or use the Visual Studio extension called [CodeMaid](http://www.codemaid.net/) to do that for you automatically on save.