### PR TITLE
Participating Organisations - RSP-7912, RSP-7899

### DIFF
--- a/src/Application/Rsp.RtsService.Application/Contracts/Services/IOrganisationService.cs
+++ b/src/Application/Rsp.RtsService.Application/Contracts/Services/IOrganisationService.cs
@@ -62,8 +62,8 @@ public interface IOrganisationService
     /// <param name="sortDirection">"asc" or "desc". Defaults to "asc".</param>
     Task<OrganisationSearchResponse> SearchOrganisations
     (
-       OrganisationsSearchRequest searchRequest,
-       int pageIndex,
+        OrganisationsSearchRequest searchRequest,
+        int pageIndex,
         int? pageSize,
         string sortField = "name",
         string sortDirection = "asc"

--- a/src/Application/Rsp.RtsService.Application/DTOS/Requests/OrganisationsSearchRequest.cs
+++ b/src/Application/Rsp.RtsService.Application/DTOS/Requests/OrganisationsSearchRequest.cs
@@ -10,4 +10,5 @@ public record OrganisationsSearchRequest
     public List<string> Countries { get; set; } = [];
     public List<string> OrganisationTypes { get; set; } = [];
     public List<bool> OrganisationStatuses { get; set; } = [];
+    public List<string> ExcludedOrganisationIds { get; set; } = [];
 }

--- a/src/Application/Rsp.RtsService.Application/Specifications/OrganisationsSearchSpecification.cs
+++ b/src/Application/Rsp.RtsService.Application/Specifications/OrganisationsSearchSpecification.cs
@@ -27,13 +27,31 @@ public class OrganisationsSearchSpecification : Specification<Organisation>
             );
         }
 
-        // Optional name filter
-        if (!string.IsNullOrWhiteSpace(request.SearchNameTerm))
+        // Optional exclusion of specific organisation IDs
+        if (request.ExcludedOrganisationIds.Count > 0)
         {
             Query.Where
             (
-                x => EF.Functions.Like(x.Name, $"%{request.SearchNameTerm}%")
+                x => !request.ExcludedOrganisationIds.Contains(x.Id)
             );
+        }
+
+        // Optional name filter
+        if (!string.IsNullOrWhiteSpace(request.SearchNameTerm))
+        {
+            var terms = request.SearchNameTerm
+               .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+               .AsEnumerable();
+
+            foreach (var term in terms)
+            {
+                var t = term; // avoid closure issues
+
+                Query.Where
+                (
+                    x => EF.Functions.Like(x.Name, $"%{t}%")
+                );
+            }
         }
 
         // Multi-country filter

--- a/src/Infrastructure/Rsp.RtsService.Infrastructure/Repositories/OrganisationRepository.cs
+++ b/src/Infrastructure/Rsp.RtsService.Infrastructure/Repositories/OrganisationRepository.cs
@@ -93,19 +93,19 @@ public class OrganisationRepository(RtsDbContext context) : IOrganisationReposit
         // perform sorting
         organisations = (sortField, sortDirection) switch
         {
-            ("name", "asc") => [.. organisations.OrderBy(x => x.Name).ThenBy(x => x.Id)],
-            ("name", "desc") => [.. organisations.OrderByDescending(x => x.Name).ThenBy(x => x.Id)],
+            ("name", "asc") => [.. organisations.OrderBy(x => x.Name)],
+            ("name", "desc") => [.. organisations.OrderByDescending(x => x.Name)],
 
-            ("address", "asc") => [.. organisations.OrderBy(x => x.Address).ThenBy(x => x.Id)],
-            ("address", "desc") => [.. organisations.OrderByDescending(x => x.Address).ThenBy(x => x.Id)],
+            ("address", "asc") => [.. organisations.OrderBy(x => x.Address)],
+            ("address", "desc") => [.. organisations.OrderByDescending(x => x.Address)],
 
-            ("type", "asc") => [.. organisations.OrderBy(x => x.Type).ThenBy(x => x.Id)],
-            ("type", "desc") => [.. organisations.OrderByDescending(x => x.Type).ThenBy(x => x.Id)],
+            ("type", "asc") => [.. organisations.OrderBy(x => x.Type)],
+            ("type", "desc") => [.. organisations.OrderByDescending(x => x.Type)],
 
-            ("country", "asc") => [.. organisations.OrderBy(x => x.CountryName).ThenBy(x => x.Id)],
-            ("country", "desc") => [.. organisations.OrderByDescending(x => x.CountryName).ThenBy(x => x.Id)],
+            ("country", "asc") => [.. organisations.OrderBy(x => x.CountryName)],
+            ("country", "desc") => [.. organisations.OrderByDescending(x => x.CountryName)],
 
-            _ => [.. organisations.OrderBy(x => x.Name).ThenBy(x => x.Id)]
+            _ => [.. organisations.OrderBy(x => x.Name)]
         };
 
         // Return the organisations and the total count

--- a/src/Services/Rsp.RtsService.Services/OrganisationService.cs
+++ b/src/Services/Rsp.RtsService.Services/OrganisationService.cs
@@ -124,7 +124,8 @@ public class OrganisationService(IOrganisationRepository repository) : IOrganisa
                 ExcludingRoles = searchRequest.ExcludingRoles,
                 Countries = searchRequest.Countries,
                 OrganisationTypes = searchRequest.OrganisationTypes,
-                OrganisationStatuses = searchRequest.OrganisationStatuses
+                OrganisationStatuses = searchRequest.OrganisationStatuses,
+                ExcludedOrganisationIds = searchRequest.ExcludedOrganisationIds
             }
         );
 


### PR DESCRIPTION
## What was the purpose of this ticket?

To fix the search using AND logic, alphabetical order and exclusion of the selected organisations

## Jira Ref

[RSP-7912](https://nihr.atlassian.net/browse/RSP-7912)
[RSP-7899](https://nihr.atlassian.net/browse/RSP-7899)

## Type of Change

Put [X] inside the [] to make the box ticked

- [ ] New feature
- [ ] Refactoring
- [X] Bug-fix
- [ ] DevOps
- [ ] Testing

## Solution

What work was completed to cover off the story?

- Added the exclusions when search for the  selected participating organisations in the search query.
- Added search for multiple search terms